### PR TITLE
Alternate Preferences approach

### DIFF
--- a/android/app/src/main/res/xml/preferences.xml
+++ b/android/app/src/main/res/xml/preferences.xml
@@ -15,38 +15,14 @@
  limitations under the License.
  -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-  <PreferenceCategory android:title="@string/menu_start">
-  <CheckBoxPreference
-      android:key="preferences_start_scan"
-      android:defaultValue="false"
-      android:title="@string/scan"/>
-  </PreferenceCategory>
+    <ListPreference
+        android:entries="@array/preferences_front_light_options"
+        android:entryValues="@array/preferences_front_light_values"
+        android:key="preferences_front_light_mode"
+        android:defaultValue="OFF"
+        android:title="@string/preferences_front_light_title"
+        android:summary="@string/preferences_front_light_summary"/>
   <PreferenceCategory android:title="@string/preferences_scanning_title">
-    <CheckBoxPreference
-        android:key="preferences_decode_1D_product"
-        android:defaultValue="true"
-        android:title="@string/preferences_decode_1D_product_title"/>
-    <CheckBoxPreference
-        android:key="preferences_decode_1D_industrial"
-        android:defaultValue="true"
-        android:title="@string/preferences_decode_1D_industrial_title"/>
-    <CheckBoxPreference
-        android:key="preferences_decode_QR"
-        android:defaultValue="true"
-        android:title="@string/preferences_decode_QR_title"/>
-    <CheckBoxPreference
-        android:key="preferences_decode_Data_Matrix"
-        android:defaultValue="true"
-        android:title="@string/preferences_decode_Data_Matrix_title"/>
-    <CheckBoxPreference
-        android:key="preferences_decode_Aztec"
-        android:defaultValue="false"
-        android:title="@string/preferences_decode_Aztec_title"/>
-    <CheckBoxPreference
-        android:key="preferences_decode_PDF417"
-        android:defaultValue="false"
-        android:title="@string/preferences_decode_PDF417_title"/>
-  </PreferenceCategory>
   <PreferenceCategory android:title="@string/preferences_actions_title">
     <CheckBoxPreference
         android:key="preferences_play_beep"


### PR DESCRIPTION
It occurs to me you may just prefer to remove the other details and only leave the one(s) you care about, which is simple enpugh. Just delete the while group, or any members of the group, to eliminate it/them. I've put this on a second pull request, if you want to eliminate options then merge this one rather than the setting-1 branch pull request, then throw out anything else you want to eliminate.